### PR TITLE
Link speaker images to twitters

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
 					<div class="mi-hove-figure">
 						<div class="mi-rect-block">
 							<figure class="mi-figure">
-								<img v-bind:src="speaker.picture" alt="image">
+								<a v-bind:href="'https://twitter.com/' + speaker.twitter" target="_blank"><img v-bind:src="speaker.picture" alt="image"></a>
 							</figure>
 							<div class="mi-rect-bg"></div>
 						</div>


### PR DESCRIPTION
The speaker images currently appear clickable on mouseover, however they don't link to anything. Maybe there's a plan to link them to the talks or something at some point, but in the meanwhile I was thinking it'd be nice if they linked to the speakers' twitters.

Otherwise, perhaps the mouseover shouldn't change the cursor. 